### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Default_Build.yml
+++ b/.github/workflows/Default_Build.yml
@@ -1,11 +1,15 @@
 name: Go
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 on:
   workflow_dispatch:
   push:
     branches: [ main ]
     
-
 
 jobs:
 


### PR DESCRIPTION
Potential fix for [https://github.com/vantmet/trackmyrun/security/code-scanning/1](https://github.com/vantmet/trackmyrun/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's steps:
- `contents: read` is needed for `actions/checkout@v3` to fetch the repository code.
- `packages: write` is required for publishing Docker images to the registry.
- `id-token: write` may be required if the workflow uses OpenID Connect for authentication (e.g., AWS ECR login).

We will add the `permissions` block at the top of the workflow, ensuring no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
